### PR TITLE
Update 2023-09-12 0946H

### DIFF
--- a/src/tmux/keybindings.conf
+++ b/src/tmux/keybindings.conf
@@ -18,9 +18,9 @@ bind | split-window -v # Bind 'Prefix + |' to split window vertically
 bind -n C-down new-window
 bind -n C-Left prev
 bind -n C-Right next
-### Switch/Swap location of the tabs using 'Ctrl+Shift+[Left|Right]'
-bind-key -n C-S-Left swap-window -t -1
-bind-key -n C-S-Right swap-window -t +1
+### Switch/Swap location of the tabs using 'Ctrl+Shift+[Left|Right]'; Changes focus to the new location of the previously-selected tab (window)
+bind-key -n C-S-Left swap-window -t -1 \; select-window -t -1
+bind-key -n C-S-Right swap-window -t +1 \; select-window -t +1
 ### Switch panes using 'Alt-[Direction]'
 bind -n S-Up select-pane -U
 bind -n S-Down select-pane -D


### PR DESCRIPTION
- Updated keybindings with add-on to 'swap-windows' keybind to change focus to the new location of the keybind so that when you move windows/tabs, it moves the focus with the tab